### PR TITLE
Corrected generating injectable files

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.50'
+    ext.kotlin_version = '1.5.30'
     repositories {
         google()
         mavenCentral()

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -47,8 +47,8 @@ dev_dependencies:
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
   flutter_lints: ^1.0.0
-  injectable_generator:
-  build_runner:
+  injectable_generator: ^1.5.3
+  build_runner: ^2.1.8
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec
 


### PR DESCRIPTION
The example is missing generator packages and because of that example was not compiled properly.

IDE forced me also to bump project kotlin version to the newest