### PR TITLE
chore: changed documentation link to a valid one

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.4.0
 repository: https://github.com/Iteo/hooked_bloc
 issue_tracker: https://github.com/Iteo/hooked_bloc/issues
 homepage: https://github.com/Iteo/hooked_bloc
-documentation: https://github.com/Iteo/hooked_bloc/blob/develop/README.md
+documentation: https://github.com/Iteo/hooked_bloc/blob/main/README.md
 
 environment:
   sdk: '>=2.17.0 <3.0.0'


### PR DESCRIPTION
The link to documentation has expired since hooked_bloc has stopped using the develop branch. I've replaced it with a link that redirects users to the main branch.